### PR TITLE
Allow unconstrained variables to be edited

### DIFF
--- a/rhea/simplex_solver.cpp
+++ b/rhea/simplex_solver.cpp
@@ -140,7 +140,7 @@ solver& simplex_solver::add_constraint_(const constraint& c)
     if (c.is_edit_constraint()) {
         auto& ec = c.as<edit_constraint>();
         const auto& v = ec.var();
-        if (!v.is_external() || (!is_basic_var(v) && !columns_has_key(v)))
+        if (!v.is_external())
             throw edit_misuse(v);
 
         auto i(std::find(edit_info_list_.begin(), edit_info_list_.end(), v));

--- a/rhea/simplex_solver.hpp
+++ b/rhea/simplex_solver.hpp
@@ -110,6 +110,14 @@ public:
         return columns_has_key(v) || is_basic_var(v);
     }
 
+    /** Check if the solver knows of a given constraint.
+     * \param c The constraint to check for
+     * \return True iff c has been added to the solver */
+    bool contains_constraint(const constraint& c)
+    {
+        return marker_vars_.find(c) != marker_vars_.end();
+    }
+
     /** Check if this constraint was satisfied. */
     bool is_constraint_satisfied(const constraint& c) const;
 

--- a/unit_tests/unit_tests.cpp
+++ b/unit_tests/unit_tests.cpp
@@ -912,3 +912,17 @@ BOOST_AUTO_TEST_CASE(add_constraints_after_marking_edit_variable)
     BOOST_CHECK_EQUAL(v.value(), 3);
     BOOST_CHECK(solver.is_valid());
 }
+
+BOOST_AUTO_TEST_CASE(contains_constraint)
+{
+    auto c = constraint{ variable{} == 42 };
+    auto solver = simplex_solver{};
+
+    BOOST_CHECK(!solver.contains_constraint(c));
+
+    solver.add_constraint(c);
+    BOOST_CHECK(solver.contains_constraint(c));
+
+    solver.remove_constraint(c);
+    BOOST_CHECK(!solver.contains_constraint(c));
+}

--- a/unit_tests/unit_tests.cpp
+++ b/unit_tests/unit_tests.cpp
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(simple2_test)
 
     simplex_solver solver;
 
-    BOOST_CHECK_THROW((solver.add_edit_var(x), solver.begin_edit(),
+    BOOST_CHECK_THROW((solver.begin_edit(),
                        solver.suggest_value(x, 100), solver.end_edit()),
                       edit_misuse);
 
@@ -870,4 +870,45 @@ BOOST_AUTO_TEST_CASE(change_weight_test) // issue 33
 
     solver.change_weight(c1, 3);
     BOOST_CHECK_EQUAL(x.value(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(edit_unconstrained_variable)
+{
+    auto v = variable{ 0 };
+    auto solver = simplex_solver{};
+
+    solver.add_edit_var(v);
+    BOOST_CHECK_EQUAL(v.value(), 0);
+    BOOST_CHECK(solver.is_valid());
+
+    solver.suggest_value(v, 2);
+    solver.resolve();
+    BOOST_CHECK_EQUAL(v.value(), 2);
+    BOOST_CHECK(solver.is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(add_constraints_after_marking_edit_variable)
+{
+    auto v = variable{ 0 };
+    auto solver = simplex_solver{};
+
+    solver.add_edit_var(v);
+    solver.suggest_value(v, 2);
+    solver.resolve();
+    BOOST_CHECK_EQUAL(v.value(), 2);
+    BOOST_CHECK(solver.is_valid());
+
+    // Constraint overrides users desire
+    auto fixed = constraint { v == 42 };
+    solver.add_constraint(fixed);
+    BOOST_CHECK_EQUAL(v.value(), 42);
+    solver.suggest_value(v, 3);
+    solver.resolve();
+    BOOST_CHECK_EQUAL(v.value(), 42);
+    BOOST_CHECK(solver.is_valid());
+
+    // Goes back to last edited value
+    solver.remove_constraint(fixed);
+    BOOST_CHECK_EQUAL(v.value(), 3);
+    BOOST_CHECK(solver.is_valid());
 }


### PR DESCRIPTION
This pull requests removes the restriction of having constraints already set up when adding an edit variable. I added tests supporting this workflow, which I did find very useful I have already tried with Cassowary.js.

Note that in these tests I do not execute `begin_edit()`, `end_edit()`. I have found examples using Cassowary.js that do not neither, and this allows me to manage edit constraints manually, thus allowing interleaved edits.

This pull request addresses https://github.com/Nocte-/rhea/issues/34